### PR TITLE
general: move utils.which to utils.path.which

### DIFF
--- a/_modules/teleport.py
+++ b/_modules/teleport.py
@@ -22,7 +22,7 @@ def __virtual__():
     '''
     Only load if tctl exists on the system
     '''
-    if salt.utils.which('tctl') is None:
+    if salt.utils.path.which('tctl') is None:
         return (False, 'The tctl execution module cannot be loaded: tctl unavailable.')
     else:
         return True

--- a/_states/teleport.py
+++ b/_states/teleport.py
@@ -18,7 +18,7 @@ def __virtual__():
     '''
     Only load if tctl exists on the system
     '''
-    if salt.utils.which('tctl') is None:
+    if salt.utils.path.which('tctl') is None:
         return (False, 'The tctl execution module cannot be loaded: tctl unavailable.')
     else:
         return True


### PR DESCRIPTION
Move to the new `salt.utils.path.which`, the old version has been deprecated since pre-2019.